### PR TITLE
using 'brunnermunzel' package

### DIFF
--- a/chapter2/chapter2_code.Rmd
+++ b/chapter2/chapter2_code.Rmd
@@ -223,45 +223,37 @@ plot(p) #上記をプロット
 ```{r}
 cor.test(working_df$Food_A, #xを指定
          working_df$BMI,    #yを指定
-         method="spearman") #Spearman's correlationを指定
+         method = "spearman") #Spearman's correlationを指定
 ```
 
 ```{r}
 cor.test(working_df$Food_A, #xを指定
          working_df$BMI,    #xを指定
-         method="pearson")  #Pearson' correlationを指定
+         method = "pearson")  #Pearson' correlationを指定
 ```
 
 ```{r}
-#男性データ抽出
-Male_df <- subset(working_df, Gender == "Male") 
-
-#女性データ抽出
-Female_df <- subset(working_df, Gender == "Female") 
+install.packages("brunnermunzel")
 ```
 
 ```{r}
-install.packages("lawstat")
-```
-
-```{r}
-library(lawstat)
-brunner.munzel.test(Male_df$Food_A, Female_df$Food_A)
+library(brunnermunzel)
+brunnermunzel.test(Food_A ~ Gender, data = working_df)
 ```
 
 ```{r}
 #Student's t-test
-t.test(Male_df$Food_A, Female_df$Food_A, var.equal=TRUE) 
+t.test(Food_A ~ Gender, data = working_df, var.equal = TRUE) 
 ```
 
 ```{r}
 #Welch's t test
-t.test(Male_df$Food_A, Female_df$Food_A, var.equal=FALSE) 
+t.test(Food_A ~ Gender, data = working_df, var.equal = FALSE) 
 ```
 
 ```{r}
 #Mann-Whitney U test
-wilcox.test(Male_df$Food_A, Female_df$Food_A) 
+wilcox.test(Food_A ~ Gender, data = working_df) 
 ```
 
 ```{r}
@@ -271,6 +263,7 @@ library(readr)
 #作業ディレクトリは適宜変更
 working_df <- read_csv("~/GitHub/ScienceR/chapter2/Data/data2_work.csv")
 
+#女性データ抽出
 Female_df <- subset(working_df, Gender == "Female") 
 ```
 


### PR DESCRIPTION
この本が出版された後にbrunnermuzelパッケージを作成しました。
引数として2群の変数を指定する方法の他に、formulaを使用できるようにしています。また、並べ替えBrunner-Munzel検定を行うための関数も用意しています。

このパッケージを使用するようにChapter2のスクリプトを少しだけ改善しました。
参考になればと思います。

- 以下、変更点です。
  - lawstat::brunner.munzel.test の代わりに
     brunnermunzel::brunnermunzel.testを使用
  - それに伴いformulaを使用した形式に変更
  - その他 